### PR TITLE
Minor cosmetic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Sample usage:
 IAmazonS3 s3 = new AmazonS3Client();
 
 IS3ZipContentHelper content = new S3ZipContentHelper(s3);
-var contentList = await content.GetContent("Bucket", "Key");
+var contentList = await content.GetContents("Bucket", "Key");
 
 foreach (var content in contentList)
    Console.WriteLine(item.FullName);

--- a/S3ZipContent/IS3ZipContentHelper.cs
+++ b/S3ZipContent/IS3ZipContentHelper.cs
@@ -6,6 +6,6 @@ namespace S3ZipContent
 {
     public interface IS3ZipContentHelper
     {
-        Task<IList<ZipEntry>> GetContent(string Bucket, string Key);
+        Task<IList<ZipEntry>> GetContent(string bucket, string key);
     }
 }

--- a/S3ZipContent/IS3ZipContentHelper.cs
+++ b/S3ZipContent/IS3ZipContentHelper.cs
@@ -6,6 +6,6 @@ namespace S3ZipContent
 {
     public interface IS3ZipContentHelper
     {
-        Task<IList<ZipEntry>> GetContent(string bucket, string key);
+        Task<IList<ZipEntry>> GetContents(string bucket, string key);
     }
 }

--- a/S3ZipContent/IS3ZipContentHelper.cs
+++ b/S3ZipContent/IS3ZipContentHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO.Compression;
 using System.Threading.Tasks;
 
 namespace S3ZipContent

--- a/S3ZipContent/S3ZipContentHelper.cs
+++ b/S3ZipContent/S3ZipContentHelper.cs
@@ -24,7 +24,7 @@ namespace S3ZipContent
             _s3 = s3;
         }
 
-        public async Task<IList<ZipEntry>> GetContent(string bucket, string key)
+        public async Task<IList<ZipEntry>> GetContents(string bucket, string key)
         {
             var metadata = await _s3.GetObjectMetadataAsync(bucket, key);
 

--- a/S3ZipContent/S3ZipContentHelper.cs
+++ b/S3ZipContent/S3ZipContentHelper.cs
@@ -11,7 +11,7 @@ namespace S3ZipContent
 {
     public class S3ZipContentHelper : IS3ZipContentHelper
     {
-        private readonly IAmazonS3 s3;
+        private readonly IAmazonS3 _s3;
 
         //https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
         static readonly byte[] eocdHeader = new byte[] { 80, 75, 5, 6 };
@@ -19,14 +19,14 @@ namespace S3ZipContent
         static readonly byte[] zip64EocdLocatorHeader = new byte[] { 80, 75, 6, 7 };
         static readonly byte[] localFileHeader = new byte[] { 80, 75, 3, 4 };
 
-        public S3ZipContentHelper(IAmazonS3 S3)
+        public S3ZipContentHelper(IAmazonS3 s3)
         {
-            s3 = S3;
+            _s3 = s3;
         }
 
         public async Task<IList<ZipEntry>> GetContent(string bucket, string key)
         {
-            var metadata = await s3.GetObjectMetadataAsync(bucket, key);
+            var metadata = await _s3.GetObjectMetadataAsync(bucket, key);
 
             var length = metadata.ContentLength;
 
@@ -108,7 +108,7 @@ namespace S3ZipContent
                 Key = key,
                 ByteRange = range
             };
-            var response = await s3.GetObjectAsync(request);
+            var response = await _s3.GetObjectAsync(request);
             return StreamToArray(response.ResponseStream);
         }
 

--- a/S3ZipContent/ZipEntry.cs
+++ b/S3ZipContent/ZipEntry.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace S3ZipContent
 {

--- a/S3ZipContentTest/S3ContentHelperTest.cs
+++ b/S3ZipContentTest/S3ContentHelperTest.cs
@@ -77,7 +77,7 @@ namespace S3ZipContentTest
         {
             s3ZipContentHelper = new S3ZipContentHelper(s3ClientMock.Object);
 
-            var content = await s3ZipContentHelper.GetContent("Test", "foo.zip");
+            var content = await s3ZipContentHelper.GetContents("Test", "foo.zip");
 
             Assert.AreEqual(content.Count, 1);
 
@@ -88,7 +88,7 @@ namespace S3ZipContentTest
         {
             s3ZipContentHelper = new S3ZipContentHelper(s3ClientMock.Object);
 
-            var content = await s3ZipContentHelper.GetContent("Test", "foo64.zip");
+            var content = await s3ZipContentHelper.GetContents("Test", "foo64.zip");
 
             Assert.AreEqual(content.Count, 1);
 
@@ -100,7 +100,7 @@ namespace S3ZipContentTest
         {
             s3ZipContentHelper = new S3ZipContentHelper(s3ClientMock.Object);
 
-            var content = await s3ZipContentHelper.GetContent("Test", "foo.zip");
+            var content = await s3ZipContentHelper.GetContents("Test", "foo.zip");
 
             Assert.AreEqual(content[0].FullName, "foo.txt");
 
@@ -111,7 +111,7 @@ namespace S3ZipContentTest
         {
             s3ZipContentHelper = new S3ZipContentHelper(s3ClientMock.Object);
 
-            var content = await s3ZipContentHelper.GetContent("Test", "foo64.zip");
+            var content = await s3ZipContentHelper.GetContents("Test", "foo64.zip");
 
             Assert.AreEqual(content[0].FullName, "Documents/foo.txt");
 
@@ -122,7 +122,7 @@ namespace S3ZipContentTest
         {
             s3ZipContentHelper = new S3ZipContentHelper(s3ClientMock.Object);
 
-            var content = await s3ZipContentHelper.GetContent("Test", "nested.zip");
+            var content = await s3ZipContentHelper.GetContents("Test", "nested.zip");
 
             Assert.AreEqual(content.Count, 1);
 
@@ -134,7 +134,7 @@ namespace S3ZipContentTest
         {
             s3ZipContentHelper = new S3ZipContentHelper(s3ClientMock.Object);
 
-            await s3ZipContentHelper.GetContent("Test", "zero-file.zip");
+            await s3ZipContentHelper.GetContents("Test", "zero-file.zip");
         }
 
 
@@ -144,7 +144,7 @@ namespace S3ZipContentTest
         {
             s3ZipContentHelper = new S3ZipContentHelper(s3ClientMock.Object);
 
-            await s3ZipContentHelper.GetContent("Test", "not-a-zip.zip");
+            await s3ZipContentHelper.GetContents("Test", "not-a-zip.zip");
             
         }
 
@@ -154,7 +154,7 @@ namespace S3ZipContentTest
         {
             s3ZipContentHelper = new S3ZipContentHelper(s3ClientMock.Object);
 
-            await s3ZipContentHelper.GetContent("Test", "zero-byte.zip");
+            await s3ZipContentHelper.GetContents("Test", "zero-byte.zip");
 
         }
     }


### PR DESCRIPTION
This PR changes name of public method `GetContent` to `GetContents` as it makes more sense because it returns a collection and the PR also includes some minor changes concerning naming conventions and removing some namespaces.